### PR TITLE
refactor: slither removal from ci

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,24 +34,3 @@ jobs:
 
       - name: Unit Tests
         run: yarn test:hardhat
-
-      - name: Run Slither
-        uses: crytic/slither-action@v0.3.1
-        id: slither
-        with:
-          ignore-compile: true
-          solc-version: "0.8.20"
-          fail-on: none
-          slither-args: --filter-paths "openzeppelin" --exclude-informational --exclude-optimization --checklist --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
-
-      - name: Create/update checklist as PR comment
-        uses: actions/github-script@v7
-        if: github.event_name == 'pull_request' && steps.contract_changes.outputs.src == 'true'
-        env:
-          REPORT: ${{ steps.slither.outputs.stdout }}
-        with:
-          script: |
-            const script = require('.github/scripts/comment')
-            const header = '# Slither report'
-            const body = process.env.REPORT
-            await script({ github, context, header, body })


### PR DESCRIPTION
Temporarily removing slither due to known issue when type parsing post compilation of contracts. 

It's an issue present also with other contract instances, for example: `slither.solc_parsing.exceptions.ParsingError: Type not found enum Crowdfund.CrowdfundLifecycle` (https://code4rena.com/audits/2023-04-party-protocol-versus-contest)