### PR TITLE
chore: update unit-tests gha upload-artifacts

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn test:coverage:solidity
 
       - name: Upload Coverage for ${{ matrix.shard }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.shard }}
           path: coverage/coverage-final.json


### PR DESCRIPTION
As per the title, upgrade upload-artifacts to v4