### PR TITLE
Release v7.0.3

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vechain/vebetterdao-contracts",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
## What's Changed
* Fix: Exporting `GrantsManager__Factory` type by @victorkl400 in https://github.com/vechain/vebetterdao-contracts/pull/52
